### PR TITLE
Release collapse 2.1.8

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -36,3 +36,11 @@ _snaps
 testthat-problems.rds
 vignettes/figure
 vignettes/cache
+vignettes/collapse_intro\.Rmd$
+vignettes/collapse_and_dplyr\.Rmd$
+vignettes/collapse_and_data\.table\.Rmd$
+vignettes/collapse_and_plm\.Rmd$
+vignettes/collapse_intro\.html$
+vignettes/collapse_and_dplyr\.html$
+vignettes/collapse_and_data\.table\.html$
+vignettes/collapse_and_plm\.html$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: collapse
 Title: Advanced and Fast Data Transformation
-Version: 2.1.7
-Date: 2026-05-17
+Version: 2.1.8
+Date: 2026-08-29
 Authors@R: c(
            person("Sebastian", "Krantz", role = c("aut", "cre"), 
                   email = "sebastian.krantz@graduateinstitute.ch", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# collapse 2.1.7
+# collapse 2.1.8
 
 * Fixed a bug in `setv()`/`copyv()` where assignments into character (`STRSXP`) or list (`VECSXP`) vectors bypassed R's generational write barrier, writing element pointers directly instead of using `SET_STRING_ELT()`/`SET_VECTOR_ELT()`. This could cause an old-generation target to hold an unrecorded reference to a younger value, which a subsequent young-generation garbage collection could free while still referenced, leading to memory corruption, cryptic `CHAR()`/`SET_STRING_ELT()` errors, or segfaults, most likely under heavy allocation in long-running processes. Thanks @SebKrantz for reporting and diagnosing (#876).
 
@@ -6,9 +6,11 @@
 
 * Fixed a bug in `fslice()` (grouped, `n = 1`, `with.ties = FALSE`) that caused R to crash with a fatal error when a group had only missing values in `order.by`. Thanks @chihyunkim for reporting (#867).
 
+# collapse 2.1.7
+
 * The *collapse* article is now published in the Journal of Statistical Software: https://doi.org/10.18637/jss.v116.i01. This article is now the primary citation for academic use of *collapse*. It is also a great reference to quickly and thoroughly understand the package. `citation("collapse")` was also updated in this regard. The APA-style citation is:
 
-  Krantz, S. (2026). **collapse**: Advanced and fast statistical computing and data transformation in R. *Journal of Statistical Software, 116*(1), 1–38. [https://doi.org/10.18637/jss.v116.i01](https://doi.org/10.18637/jss.v116.i01).
+  Krantz, S. (2026). **collapse**: Advanced and fast statistical computing and data transformation in R. *Journal of Statistical Software, 116*(1), 1–38. [https://doi.org/10.18637/jss.v116.i01](https://doi.org/10.18637/jss.v116.i01)
 
 
 * Performance improvements to `fsum()` and `fmean()` in the non-grouped case through multiple-accumulator SIMD optimizations, particularly benefiting systems without OpenMP support. `fsum()` sees ~2x speedup and `fmean()` ~7x speedup on such systems, with smaller but notable gains on systems with OpenMP. Thanks @TylerSagendorf for the implementation and benchmarking (#824, #828, #832, #833).

--- a/vignettes/collapse_documentation.Rmd
+++ b/vignettes/collapse_documentation.Rmd
@@ -32,7 +32,7 @@ Reading `help("collapse-package")` and `help("collapse-documentation")` is the m
 
 ## DeepWiki
 
-[DeepWiki](https://deepwiki.com/) is an AI-powered platform designed to automatically generate structured, interactive documentation for software repositories, primarily on GitHub. Developed by [Cognition AI](https://cognition.ai/)—the same laboratory behind the autonomous AI engineer [Devin](https://devin.ai/)—it serves as a dynamic, "Wikipedia-like" encyclopedia for codebases.
+[DeepWiki](https://deepwiki.com/) is an AI-powered platform designed to automatically generate structured, interactive documentation for software repositories, primarily on GitHub. Developed by [Cognition AI](https://cognition.com/)—the same laboratory behind the autonomous AI engineer [Devin](https://devin.ai/)—it serves as a dynamic, "Wikipedia-like" encyclopedia for codebases.
 
 While not more comprehensive or accurate than the structured documentation, it is great to learn more about the internal structure of *collapse* and use a chatbot (Devin) to ask questions about or write code using *collapse*. 
 


### PR DESCRIPTION
## Summary
- Bump version to 2.1.8 (date 2026-08-29)
- Move the setv()/copyv() write-barrier fix (#876), fmatch() logical-NA fix (#870), and fslice() crash fix (#867) — merged after the 2.1.7 tag — into a new NEWS.md section for 2.1.8
- Fix a moved CRAN-check URL (cognition.ai -> cognition.com) in the documentation vignette

## Test plan
- [x] `R CMD build .`
- [x] `R CMD check --as-cran collapse_2.1.8.tar.gz` — 0 errors, 0 warnings, 1 benign NOTE (transient 429 on an external URL during the check run)
- [x] Full testthat suite (48 files) passes
- [x] Examples and vignette re-building pass